### PR TITLE
feat: 송금 이력 남기기 시, 예외에 대한 DLQ를 이용한 보상 트랜잭션 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+build/
 
 # Build output directories
 /bin/
@@ -12,6 +13,8 @@
 !**/src/test/**/bin/
 !**/src/main/**/out/
 !**/src/test/**/out/
+bin/
+
 
 # IDE specific files
 .idea/

--- a/app/src/main/resources/application-dev.yml
+++ b/app/src/main/resources/application-dev.yml
@@ -1,1 +1,2 @@
-logging.config=classpath:logback-dev.xml
+logging:
+  config: classpath:logback-dev.xml

--- a/app/src/main/resources/application-local.yml
+++ b/app/src/main/resources/application-local.yml
@@ -1,1 +1,2 @@
-logging.config=classpath:logback-local.xml
+logging:
+  config: classpath:logback-local.xml

--- a/app/src/main/resources/application-prod.yml
+++ b/app/src/main/resources/application-prod.yml
@@ -1,1 +1,2 @@
-logging.config=classpath:logback-prod.xml
+logging:
+  config: classpath:logback-prod.xml

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -51,9 +51,9 @@ management:
           autotime:
             enabled: true
 
-logging:
-  level:
-    root: Info
+#logging:
+#  level:
+#    root: Info
 #    org:
 #      hibernate:
 #        engine:

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     name: mini-pay
 
   profiles:
-    active: oracle,dev  # 현재 활성화할 프로파일 지정
+    active: oracle,dev,value  # 현재 활성화할 프로파일 지정
 
   #항목	            prod	        dev	            local
   #로그 태그	        prod	        dev	            local
@@ -51,4 +51,6 @@ logging:
 #      .springframework:
 #        transaction: TRACE
 
-
+slack:
+  token: ${SLACK_TOKEN}
+  channel: ${SLACK_CHANNEL}

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -36,6 +36,21 @@ springdoc:
   swagger-ui:
     tags-sorter: alpha
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+      # base-path: / # /metrics 로 바로 접근하고 싶다면 이 주석을 해제하고 아래 path-mapping 추가
+      # path-mapping:
+      #   prometheus: metrics # /actuator/prometheus 대신 /metrics 로 매핑
+  metrics:
+    web:
+      server:
+        request:
+          autotime:
+            enabled: true
+
 logging:
   level:
     root: Info

--- a/app/src/main/resources/logback-dev.xml
+++ b/app/src/main/resources/logback-dev.xml
@@ -25,6 +25,15 @@
         </encoder>
     </appender>
 
+
+    <logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <logger name="org.hibernate.orm.jdbc.bind" level="TRACE" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
     <root level="trace">
         <appender-ref ref="CONSOLE"/>
         <appender-ref ref="FILE"/>

--- a/app/src/main/resources/logback-dev.xml
+++ b/app/src/main/resources/logback-dev.xml
@@ -1,21 +1,36 @@
 <configuration>
     <property name="LOG_FILE" value="log/application.log"/>
 
+    <!-- ✅ Logstash 전송용 : Logstash 로 전송할 Appender -->
     <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
 <!--        <destination>172.22.0.4:5044</destination>-->
-            <destination>localhost:5044</destination> <!-- 실제 logstash IP 주소를 사용해야 함 지금은 실습이라 localhost:5044 -->
 <!--        <destination>host.docker.internal:5044</destination>-->
+        <destination>localhost:5044</destination> <!-- 실제 logstash IP 주소를 사용해야 함 지금은 실습이라 localhost:5044 -->
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <includeLevelValue>false</includeLevelValue>
         </encoder>
     </appender>
 
+    <!-- 콘솔 출력 -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss} dev %-5level [%thread] %logger{36} - %msg%n</pattern>
         </encoder>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
     </appender>
 
+    <!-- SQL 전용 콘솔 출력 (TRACE 레벨) -->
+    <appender name="SQL_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} dev %-5level [%thread] %logger{36} - %msg%n</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>TRACE</level>
+        </filter>
+    </appender>
+
+    <!-- ✅ 로컬 저장용 : 파일 출력 -->
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_FILE}</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
@@ -25,18 +40,29 @@
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level [%thread] %logger{36} - %msg%n</pattern>
         </encoder>
+<!--        지정된 임계점(threshold)보다 낮은 레벨의 로그는 아예 그 Appender로 통과시키지 않고 버립니다.-->
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
     </appender>
 
 
+    <!--    <logger> 태그는 애플리케이션 내의 특정 패키지(또는 클래스)에 해당하는 로거(Logger)에 대해 개별적인 로깅 레벨과 연결할 Appender를 설정할 때 사용-->
     <logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
-        <appender-ref ref="CONSOLE"/>
+        <!--        additivity="false"로 설정되어 있으므로, -->
+        <!--        org.hibernate.SQL에서 발생하는 모든 DEBUG 레벨 이상의 로그 이벤트는 오직 명시된 Appender(CONSOLE Appender)로만 전달-->
+        <appender-ref ref="SQL_CONSOLE"/>
     </logger>
 
     <logger name="org.hibernate.orm.jdbc.bind" level="TRACE" additivity="false">
-        <appender-ref ref="CONSOLE"/>
+        <!--        SQL 파라미터 바인딩 정보를 TRACE 레벨로 콘솔에만 출력-->
+        <appender-ref ref="SQL_CONSOLE"/>
     </logger>
 
-    <root level="trace">
+    <!--    <root> 태그는 Logback의 최상위(root) 로거를 설정합니다. 모든 로거들은 계층적으로 root 로거 아래에 존재합니다. -->
+    <!--    특정 <logger>로 설정되지 않은 모든 로그 이벤트는 최종적으로 root 로거-->
+    <!--    INFO 이상의 레벨만 아래 작업들을 수행 (일반 애플리케이션 로그)-->
+    <root level="INFO">
         <appender-ref ref="CONSOLE"/>
         <appender-ref ref="FILE"/>
         <appender-ref ref="LOGSTASH"/>

--- a/app/src/main/resources/logback-dev.xml
+++ b/app/src/main/resources/logback-dev.xml
@@ -2,10 +2,12 @@
     <property name="LOG_FILE" value="log/application.log"/>
 
     <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
-<!--        <destination>localhost:5044</destination>-->
-        <destination>172.22.0.4:5044</destination>
+<!--        <destination>172.22.0.4:5044</destination>-->
+            <destination>localhost:5044</destination> <!-- 실제 logstash IP 주소를 사용해야 함 지금은 실습이라 localhost:5044 -->
 <!--        <destination>host.docker.internal:5044</destination>-->
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeLevelValue>false</includeLevelValue>
+        </encoder>
     </appender>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
@@ -17,7 +19,7 @@
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_FILE}</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>log/application.%d{yyyy-MM-dd_HH-mm}.log</fileNamePattern>
+            <fileNamePattern>log/application.%d{yyyy-MM-dd_HH}.log</fileNamePattern>
             <maxHistory>30</maxHistory>
         </rollingPolicy>
         <encoder>

--- a/app/src/main/resources/logback.xml
+++ b/app/src/main/resources/logback.xml
@@ -6,6 +6,7 @@
     <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>localhost:5044</destination> <!-- 실제 logstash IP 주소를 사용해야 함 지금은 실습이라 localhost:5044 -->
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+            <includeLevelValue>false</includeLevelValue>
         <!-- Elasticsearch Multi-head 의 Browser 의 Result Source 를 보면 json 형태의 값들을 볼 수 있는데 이 작업은 <encoder class="net.logstash.logback.encoder.LogstashEncoder" /> 가 해주고 있다 -->
     </appender>
 

--- a/app/src/main/resources/logback.xml
+++ b/app/src/main/resources/logback.xml
@@ -1,3 +1,7 @@
+<!--로그 이벤트가 발생하면 이 로그 이벤트는 Logback 시스템 내부로 전달됩니다. -->
+<!--이때 root 로거에 LOGSTASH Appender가 연결되어 있기 때문에, 이 로그 이벤트는:-->
+<!--파일에 기록됩니다 (FILE Appender에 의해).-->
+<!--동시에 LogstashTcpSocketAppender에도 전달됩니다.-->
 <configuration>
     <!-- property 는 파일 내에서 사용할 변수를 지정해주는 것 LOG_FILE 은 변수명 application.log 는 값 -->
     <property name="LOG_FILE" value="log/application.log"/>

--- a/app/src/main/resources/logback.xml
+++ b/app/src/main/resources/logback.xml
@@ -10,7 +10,6 @@
     <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>localhost:5044</destination> <!-- 실제 logstash IP 주소를 사용해야 함 지금은 실습이라 localhost:5044 -->
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <includeLevelValue>false</includeLevelValue>
         </encoder>
         <!-- Elasticsearch Multi-head 의 Browser 의 Result Source 를 보면 json 형태의 값들을 볼 수 있는데 이 작업은 <encoder class="net.logstash.logback.encoder.LogstashEncoder" /> 가 해주고 있다 -->
     </appender>

--- a/app/src/main/resources/logback.xml
+++ b/app/src/main/resources/logback.xml
@@ -5,8 +5,9 @@
     <!-- ✅ Logstash 전송용 : Logstash 로 전송할 Appender -->
     <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>localhost:5044</destination> <!-- 실제 logstash IP 주소를 사용해야 함 지금은 실습이라 localhost:5044 -->
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <includeLevelValue>false</includeLevelValue>
+        </encoder>
         <!-- Elasticsearch Multi-head 의 Browser 의 Result Source 를 보면 json 형태의 값들을 볼 수 있는데 이 작업은 <encoder class="net.logstash.logback.encoder.LogstashEncoder" /> 가 해주고 있다 -->
     </appender>
 

--- a/batch/src/main/java/org/c4marathon/assignment/DlqRetryBatchScheduler.java
+++ b/batch/src/main/java/org/c4marathon/assignment/DlqRetryBatchScheduler.java
@@ -1,0 +1,32 @@
+package org.c4marathon.assignment;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.c4marathon.assignment.usecase.dlq.DlqUsecase;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DlqRetryBatchScheduler {
+
+	private final DlqUsecase dlqUsecase;
+
+    @Scheduled(fixedDelay = 60000) // 작업이 끝난 뒤 1분 후 실행
+    @Transactional
+    public void processDlqCreateTransferLogEntries() {
+		log.info("DLQ 재처리 시작...");
+
+		while (true) {
+			int processedCount = dlqUsecase.processDlqBatch(50);
+			log.info("이번 루프에서 처리한 개수: {}", processedCount);
+			if (processedCount == 0) {
+				break;
+			}
+		}
+		log.info("DLQ 재처리 완료. 현재 DLQ 큐에 남은 개수: {}", dlqUsecase.getMQSize());
+	}
+}

--- a/batch/src/main/java/org/c4marathon/assignment/DlqScheduler.java
+++ b/batch/src/main/java/org/c4marathon/assignment/DlqScheduler.java
@@ -11,13 +11,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class DlqRetryBatchScheduler {
+public class DlqScheduler {
+
+	// private static final int DLQ_THRESHOLD = 2_000_000; // 4GB 힙 메모리 기준, 200만 개면 50% 차지.
+	private static final int DLQ_THRESHOLD = 100;
 
 	private final DlqUsecase dlqUsecase;
 
-    @Scheduled(fixedDelay = 60000) // 작업이 끝난 뒤 1분 후 실행
-    @Transactional
-    public void processDlqCreateTransferLogEntries() {
+	@Scheduled(fixedDelay = 60000) // 작업이 끝난 뒤 1분 후 실행
+	@Transactional
+	public void processDlqCreateTransferLogEntries() {
 		log.info("DLQ 재처리 시작...");
 
 		while (true) {
@@ -29,4 +32,11 @@ public class DlqRetryBatchScheduler {
 		}
 		log.info("DLQ 재처리 완료. 현재 DLQ 큐에 남은 개수: {}", dlqUsecase.getMQSize());
 	}
+
+	@Scheduled(cron = "0 * * * * *")
+	@Transactional(readOnly = true)
+	public void checkDlqMessageCount() {
+		dlqUsecase.checkDlqMessageCount(DLQ_THRESHOLD);
+	}
+
 }

--- a/batch/src/main/java/org/c4marathon/assignment/PendingTransferScheduler.java
+++ b/batch/src/main/java/org/c4marathon/assignment/PendingTransferScheduler.java
@@ -1,10 +1,8 @@
 package org.c4marathon.assignment;
 
-
 import org.c4marathon.assignment.usecase.transfer.PendingTransferUseCase;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,21 +28,19 @@ public class PendingTransferScheduler {
 	// }
 
 	@Scheduled(fixedDelay = 60000)
-	@Transactional
 	public void remindPendingTargetTransactionsByImproved() {
 		try {
 			pendingTransferUseCase.remindPendingTargetTransactionsByImproved();
 		} catch (Exception e) {
-			log.error("[Good] 대기 중인 송금에 대한 알림 중 오류 발생", e);
+			log.error("대기 중인 송금에 대한 알림 중 오류 발생", e);
 		}
 	}
 
 	// Todo: 배치 처리 또는 chunk 단위 업데이트, 혹은 비동기 처리 , 재시도 전략
 	@Scheduled(fixedDelay = 60000)
-	@Transactional
 	public void expireTargetTransactions() {
 		try {
-			pendingTransferUseCase.expirePendingTransfer();
+			pendingTransferUseCase.expirePendingTransferList();
 			log.info("시간이 지난 대기 중이던 트랜잭션 만료 완료");
 		} catch (Exception e) {
 			log.error("시간이 지난 대기 중이던 트랜잭션 만료 중 오류 발생", e);

--- a/build.gradle
+++ b/build.gradle
@@ -177,6 +177,19 @@ project(':transfer-log-infra') {
     }
 }
 
+project(':dlq-infra') {
+    configureQueryDsl(project)
+    databaseDependencies(project)
+
+    dependencies {
+        implementation project(':common')
+        implementation project(':transfer-log-domain')
+        implementation project(':dlq-domain')
+
+        implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    }
+}
+
 //---- 🌟 Domain Layer ----
 project(':member-domain') {
     dependencies {
@@ -233,6 +246,14 @@ project(':transfer-log-domain') {
     }
 }
 
+project(':dlq-domain') {
+    dependencies {
+        implementation 'org.springframework:spring-context'
+
+        implementation project(':common')
+    }
+}
+
 project(':reminder') {
     dependencies {
         implementation 'org.springframework:spring-context'
@@ -242,6 +263,8 @@ project(':reminder') {
         implementation project(':common')
     }
 }
+
+
 
 //---- 🌐 Interface Layer ----
 project(':interface') {
@@ -262,6 +285,8 @@ project(':interface') {
         implementation project(':settlement-domain')
         implementation project(':transfer-domain')
         implementation project(':transfer-log-domain')
+        implementation project(':dlq-domain')
+        implementation project(':dlq-infra')  // 🔥 이 라인 추가
         implementation project(':common')
     }
 }
@@ -269,6 +294,11 @@ project(':interface') {
 project(':batch') {
     dependencies {
         implementation project(':interface')
+        implementation project(':dlq-domain')
+        implementation project(':transfer-log-domain')
+
+        implementation project(':common')
+        implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
         implementation "org.springframework.boot:spring-boot-starter-batch"
     }
 }
@@ -318,7 +348,10 @@ project(':app') {
         implementation project(':transfer-infra')
         implementation project(':transfer-log-domain')
         implementation project(':transfer-log-infra')
+        implementation project(':dlq-domain')
+        implementation project(':dlq-infra')
         implementation project(':interface')
         implementation project(':common')
+        implementation project(':batch')
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -325,6 +325,12 @@ project(':common') {
 
 project(':app') {
     dependencies {
+        // Spring Boot Actuator: 애플리케이션 모니터링 및 관리 엔드포인트 제공
+        implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+        // Micrometer Prometheus Registry: Actuator 메트릭을 Prometheus 형식으로 변환
+        runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
         // logstash
         implementation "net.logstash.logback:logstash-logback-encoder:${logstashVersion}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -241,6 +241,7 @@ project(':transfer-domain') {
 project(':transfer-log-domain') {
     dependencies {
         implementation 'org.springframework:spring-context'
+        implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
 
         implementation project(':common')
     }

--- a/build.gradle
+++ b/build.gradle
@@ -259,6 +259,9 @@ project(':reminder') {
     dependencies {
         implementation 'org.springframework:spring-context'
 
+        // slack
+        implementation "com.slack.api:slack-api-client:${slackVersion}" // 슬랙 API 클라이언트
+
         implementation project(':member-domain')
         implementation project(':transfer-domain')
         implementation project(':common')
@@ -297,8 +300,8 @@ project(':batch') {
         implementation project(':interface')
         implementation project(':dlq-domain')
         implementation project(':transfer-log-domain')
-
         implementation project(':common')
+
         implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
         implementation "org.springframework.boot:spring-boot-starter-batch"
     }

--- a/common/src/main/java/org/c4marathon/assignment/enums/TransferType.java
+++ b/common/src/main/java/org/c4marathon/assignment/enums/TransferType.java
@@ -1,5 +1,8 @@
 package org.c4marathon.assignment.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum TransferType {
 	IMMEDIATE,
 	PENDING,
@@ -20,4 +23,14 @@ public enum TransferType {
 			case PENDING -> status == TransferStatus.COMPLETED;
 		};
 	}
+
+	@JsonValue
+    public String getValue() {
+        return name();
+    }
+
+    @JsonCreator
+    public static TransferType fromValue(String value) {
+        return valueOf(value);
+    }
 }

--- a/common/src/main/java/org/c4marathon/assignment/pagination/PageResult.java
+++ b/common/src/main/java/org/c4marathon/assignment/pagination/PageResult.java
@@ -1,8 +1,6 @@
 package org.c4marathon.assignment.pagination;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/dlq-domain/src/main/java/org/c4marathon/assignment/domain/model/DlqEntry.java
+++ b/dlq-domain/src/main/java/org/c4marathon/assignment/domain/model/DlqEntry.java
@@ -1,0 +1,71 @@
+package org.c4marathon.assignment.domain.model;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor // JPA 엔티티 매핑을 위해 기본 생성자 추가
+@AllArgsConstructor // 모든 필드를 인자로 받는 생성자 추가
+public class DlqEntry {
+    private String id; // DLQ 엔트리의 고유 식별자 (UUID)
+    private String operationType; // 실패한 작업의 유형 (예: "CREATE_TRANSFER_LOG")
+    private String payload;       // 실패한 작업을 재처리하는 데 필요한 데이터 (JSON 형태)
+    private String failureReason; // 작업 실패의 원인 (예외 메시지 또는 스택 트레이스 요약)
+    private LocalDateTime failedAt; // 작업이 처음 실패한 시간
+    private int retryCount;       // 현재까지 재시도한 횟수
+    private DlqStatus status;     // DLQ 엔트리의 현재 상태 (PENDING, PROCESSING, SUCCESS, FAILED)
+    private LocalDateTime nextRetryAt; // 다음 재시도를 시도할 시간
+
+    // Compact constructor for initial creation (delegates to AllArgsConstructor)
+    public DlqEntry(String operationType, String payload, String failureReason) {
+        this.id = UUID.randomUUID().toString();
+        this.operationType = operationType;
+        this.payload = payload;
+        this.failureReason = failureReason;
+        this.failedAt = LocalDateTime.now();
+        this.retryCount = 0;
+        this.status = DlqStatus.PENDING;
+        this.nextRetryAt = LocalDateTime.now().plusMinutes(1); // Initial retry after 1 minute
+    }
+
+    // Methods for state changes - modify current instance and return this
+    public void incrementRetryCount() {
+        this.retryCount++;
+	}
+
+    public void markAsProcessing() {
+        this.status = DlqStatus.PROCESSING;
+	}
+
+    public void markAsSuccess() {
+        this.status = DlqStatus.SUCCESS;
+	}
+
+    public void markAsFailed() {
+        this.status = DlqStatus.FAILED;
+	}
+
+    public void markAsPending() {
+        this.status = DlqStatus.PENDING;
+	}
+
+    public void calculateNextRetryTime() {
+        if (this.retryCount == 1) {
+            this.nextRetryAt = this.failedAt.plusMinutes(1);
+        } else if (this.retryCount == 2) {
+            this.nextRetryAt = this.failedAt.plusMinutes(10);
+        } else if (this.retryCount == 3) {
+            this.nextRetryAt = this.failedAt.plusMinutes(30);
+        } else {
+            // Beyond 3 retries, mark as failed permanently
+            this.status = DlqStatus.FAILED;
+            this.nextRetryAt = null; // No more retries
+        }
+	}
+}

--- a/dlq-domain/src/main/java/org/c4marathon/assignment/domain/model/DlqStatus.java
+++ b/dlq-domain/src/main/java/org/c4marathon/assignment/domain/model/DlqStatus.java
@@ -1,0 +1,5 @@
+package org.c4marathon.assignment.domain.model;
+
+public enum DlqStatus {
+	PENDING, PROCESSING, SUCCESS, FAILED
+}

--- a/dlq-domain/src/main/java/org/c4marathon/assignment/domain/port/DlqEntryPublisherPort.java
+++ b/dlq-domain/src/main/java/org/c4marathon/assignment/domain/port/DlqEntryPublisherPort.java
@@ -15,7 +15,7 @@ public interface DlqEntryPublisherPort {
 
 	void offer(DlqEntry savedEntity);
 
-	void replaceById(DlqEntry entry);
+	void removeFromDlqById(DlqEntry entry);
 
 	int size();
 }

--- a/dlq-domain/src/main/java/org/c4marathon/assignment/domain/port/DlqEntryPublisherPort.java
+++ b/dlq-domain/src/main/java/org/c4marathon/assignment/domain/port/DlqEntryPublisherPort.java
@@ -15,7 +15,7 @@ public interface DlqEntryPublisherPort {
 
 	void offer(DlqEntry savedEntity);
 
-	void removeIf(DlqEntry entry);
+	void replaceById(DlqEntry entry);
 
 	int size();
 }

--- a/dlq-domain/src/main/java/org/c4marathon/assignment/domain/port/DlqEntryPublisherPort.java
+++ b/dlq-domain/src/main/java/org/c4marathon/assignment/domain/port/DlqEntryPublisherPort.java
@@ -1,0 +1,21 @@
+package org.c4marathon.assignment.domain.port;
+
+import java.util.List;
+
+import org.c4marathon.assignment.domain.model.DlqEntry;
+
+public interface DlqEntryPublisherPort {
+
+	/**
+	 * 재처리를 위해 DLQ에서 처리 대기 중인 엔트리를 가져옵니다.
+	 * @param limit 가져올 엔트리의 최대 개수
+	 * @return 처리 대기 중인 DLQ 엔트리 목록
+	 */
+	List<DlqEntry> findPendingCreateTransferLogEntries(int limit);
+
+	void offer(DlqEntry savedEntity);
+
+	void removeIf(DlqEntry entry);
+
+	int size();
+}

--- a/dlq-domain/src/main/java/org/c4marathon/assignment/domain/port/DlqEntryStoragePort.java
+++ b/dlq-domain/src/main/java/org/c4marathon/assignment/domain/port/DlqEntryStoragePort.java
@@ -1,0 +1,13 @@
+package org.c4marathon.assignment.domain.port;
+
+import java.util.List;
+
+import org.c4marathon.assignment.domain.model.DlqEntry;
+import org.c4marathon.assignment.domain.model.DlqStatus;
+import org.c4marathon.assignment.pagination.PageRequest;
+
+public interface DlqEntryStoragePort {
+
+	List<DlqEntry> findByStatusOrderByFailedAtAsc(DlqStatus status, PageRequest pageable);
+	DlqEntry save(DlqEntry dlqEntry);
+}

--- a/dlq-domain/src/main/java/org/c4marathon/assignment/domain/service/DlqEntryService.java
+++ b/dlq-domain/src/main/java/org/c4marathon/assignment/domain/service/DlqEntryService.java
@@ -45,7 +45,7 @@ public class DlqEntryService {
 	public void update(DlqEntry entry) {
 		DlqEntry updatedEntity = dlqEntryStoragePort.save(entry); // save는 upsert 역할
 		// 인메모리 큐에서도 업데이트 (기존 엔트리 제거 후 새 엔트리 추가)
-		dlqEntryPublisherPort.replaceById(entry);
+		dlqEntryPublisherPort.replaceById(updatedEntity);
 		dlqEntryPublisherPort.offer(updatedEntity);
 	}
 

--- a/dlq-domain/src/main/java/org/c4marathon/assignment/domain/service/DlqEntryService.java
+++ b/dlq-domain/src/main/java/org/c4marathon/assignment/domain/service/DlqEntryService.java
@@ -43,9 +43,10 @@ public class DlqEntryService {
 	 * @param entry 업데이트할 DLQ 엔트리
 	 */
 	public void update(DlqEntry entry) {
-		DlqEntry updatedEntity = dlqEntryStoragePort.save(entry); // save는 upsert 역할
+		dlqEntryPublisherPort.removeFromDlqById(entry);
+
 		// 인메모리 큐에서도 업데이트 (기존 엔트리 제거 후 새 엔트리 추가)
-		dlqEntryPublisherPort.replaceById(updatedEntity);
+		DlqEntry updatedEntity = dlqEntryStoragePort.save(entry);
 		dlqEntryPublisherPort.offer(updatedEntity);
 	}
 
@@ -57,7 +58,7 @@ public class DlqEntryService {
 	public void markAsProcessedAndCleanUp(DlqEntry entry) {
 		dlqEntryStoragePort.save(entry);
 		// 인메모리 큐에서도 업데이트 (기존 엔트리 제거)
-		dlqEntryPublisherPort.replaceById(entry);
+		dlqEntryPublisherPort.removeFromDlqById(entry);
 	}
 
 	public int getMQSize() {

--- a/dlq-domain/src/main/java/org/c4marathon/assignment/domain/service/DlqEntryService.java
+++ b/dlq-domain/src/main/java/org/c4marathon/assignment/domain/service/DlqEntryService.java
@@ -1,0 +1,66 @@
+package org.c4marathon.assignment.domain.service;
+
+import java.util.List;
+
+import org.c4marathon.assignment.domain.model.DlqEntry;
+import org.c4marathon.assignment.domain.port.DlqEntryPublisherPort;
+import org.c4marathon.assignment.domain.port.DlqEntryStoragePort;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DlqEntryService {
+
+	private final DlqEntryStoragePort dlqEntryStoragePort; // JPA 어댑터가 주입될 것임
+	private final DlqEntryPublisherPort dlqEntryPublisherPort; // RabbitMQ 어댑터가 주입될 것임
+
+	/**
+	 * DLQ에 새로운 엔트리를 추가합니다.
+	 *
+	 * @param entry 추가할 DLQ 엔트리
+	 */
+	// @Transactional(propagation = Propagation.REQUIRES_NEW) // 새로운 트랜잭션에서 실행
+	public void save(DlqEntry entry) {
+		DlqEntry savedEntity = dlqEntryStoragePort.save(entry);
+		// DB에 저장 성공 후 인메모리 큐에도 추가
+		dlqEntryPublisherPort.offer(savedEntity);
+	}
+
+	/**
+	 * 재처리를 위해 DLQ에서 처리 대기 중인 엔트리를 가져옵니다.
+	 * @param limit 가져올 엔트리의 최대 개수
+	 * @return 처리 대기 중인 DLQ 엔트리 목록
+	 */
+	public List<DlqEntry> findPendingCreateTransferLogEntries(int limit) {
+		return dlqEntryPublisherPort.findPendingCreateTransferLogEntries(limit);
+	}
+
+	/**
+	 * DLQ 엔트리의 상태를 업데이트합니다.
+	 *
+	 * @param entry 업데이트할 DLQ 엔트리
+	 */
+	public void update(DlqEntry entry) {
+		DlqEntry updatedEntity = dlqEntryStoragePort.save(entry); // save는 upsert 역할
+		// 인메모리 큐에서도 업데이트 (기존 엔트리 제거 후 새 엔트리 추가)
+		dlqEntryPublisherPort.removeIf(entry);
+		dlqEntryPublisherPort.offer(updatedEntity);
+	}
+
+	/**
+	 * 항목이 처리(저장소 업데이트)되었음을 표시하고, 동시에 관련 임시 데이터를 정리(인메모리 큐에서 제거)
+	 *
+	 * @param entry 업데이트할 DLQ 엔트리
+	 */
+	public void markAsProcessedAndCleanUp(DlqEntry entry) {
+		dlqEntryStoragePort.save(entry);
+		// 인메모리 큐에서도 업데이트 (기존 엔트리 제거)
+		dlqEntryPublisherPort.removeIf(entry);
+	}
+
+	public int getMQSize() {
+		return dlqEntryPublisherPort.size();
+	}
+}

--- a/dlq-domain/src/main/java/org/c4marathon/assignment/domain/service/DlqEntryService.java
+++ b/dlq-domain/src/main/java/org/c4marathon/assignment/domain/service/DlqEntryService.java
@@ -13,8 +13,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class DlqEntryService {
 
-	private final DlqEntryStoragePort dlqEntryStoragePort; // JPA 어댑터가 주입될 것임
-	private final DlqEntryPublisherPort dlqEntryPublisherPort; // RabbitMQ 어댑터가 주입될 것임
+	private final DlqEntryStoragePort dlqEntryStoragePort;
+	private final DlqEntryPublisherPort dlqEntryPublisherPort;
 
 	/**
 	 * DLQ에 새로운 엔트리를 추가합니다.

--- a/dlq-domain/src/main/java/org/c4marathon/assignment/domain/service/DlqEntryService.java
+++ b/dlq-domain/src/main/java/org/c4marathon/assignment/domain/service/DlqEntryService.java
@@ -45,7 +45,7 @@ public class DlqEntryService {
 	public void update(DlqEntry entry) {
 		DlqEntry updatedEntity = dlqEntryStoragePort.save(entry); // save는 upsert 역할
 		// 인메모리 큐에서도 업데이트 (기존 엔트리 제거 후 새 엔트리 추가)
-		dlqEntryPublisherPort.removeIf(entry);
+		dlqEntryPublisherPort.replaceById(entry);
 		dlqEntryPublisherPort.offer(updatedEntity);
 	}
 
@@ -57,7 +57,7 @@ public class DlqEntryService {
 	public void markAsProcessedAndCleanUp(DlqEntry entry) {
 		dlqEntryStoragePort.save(entry);
 		// 인메모리 큐에서도 업데이트 (기존 엔트리 제거)
-		dlqEntryPublisherPort.removeIf(entry);
+		dlqEntryPublisherPort.replaceById(entry);
 	}
 
 	public int getMQSize() {

--- a/dlq-infra/src/main/java/org/c4marathon/assignment/infra/adapter/DlqEntryJpaAdapter.java
+++ b/dlq-infra/src/main/java/org/c4marathon/assignment/infra/adapter/DlqEntryJpaAdapter.java
@@ -1,0 +1,41 @@
+package org.c4marathon.assignment.infra.adapter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.c4marathon.assignment.domain.port.DlqEntryStoragePort;
+import org.c4marathon.assignment.infra.persistence.entity.DlqEntryJpaEntity;
+import org.c4marathon.assignment.infra.persistence.repository.jpa.JpaDlqEntryRepository;
+import org.c4marathon.assignment.domain.model.DlqEntry;
+import org.c4marathon.assignment.domain.model.DlqStatus;
+import org.c4marathon.assignment.pagination.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class DlqEntryJpaAdapter implements DlqEntryStoragePort {
+
+    private final JpaDlqEntryRepository jpaDlqEntryRepository;
+
+    @Override
+    public List<DlqEntry> findByStatusOrderByFailedAtAsc(DlqStatus status, PageRequest pageable) {
+		Pageable springPageable =
+			org.springframework.data.domain.PageRequest.of(
+				pageable.getPage(),
+				pageable.getSize()
+			);
+
+        return jpaDlqEntryRepository.findByStatusOrderByFailedAtAsc(status, springPageable).stream()
+                .map(DlqEntryJpaEntity::toDomain)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public DlqEntry save(DlqEntry dlqEntry) {
+        DlqEntryJpaEntity entity = new DlqEntryJpaEntity(dlqEntry);
+        return jpaDlqEntryRepository.save(entity).toDomain();
+    }
+}

--- a/dlq-infra/src/main/java/org/c4marathon/assignment/infra/adapter/DlqEntryPQAdapter.java
+++ b/dlq-infra/src/main/java/org/c4marathon/assignment/infra/adapter/DlqEntryPQAdapter.java
@@ -51,8 +51,8 @@ public class DlqEntryPQAdapter implements DlqEntryPublisherPort {
 	}
 
 	@Override
-	public void replaceById(DlqEntry entry) {
-		// 인메모리 큐에서도 업데이트 (기존 엔트리 제거 후 새 엔트리 추가)
+	public void removeFromDlqById(DlqEntry entry) {
+		// inMemoryDlq에 저장된 항목들 중에서 entry라는 객체와 동일한 ID를 가진 모든 항목을 제거하는 역할
 		inMemoryDlq.removeIf(e -> e.getId().equals(entry.getId()));
 	}
 

--- a/dlq-infra/src/main/java/org/c4marathon/assignment/infra/adapter/DlqEntryPQAdapter.java
+++ b/dlq-infra/src/main/java/org/c4marathon/assignment/infra/adapter/DlqEntryPQAdapter.java
@@ -1,0 +1,69 @@
+package org.c4marathon.assignment.infra.adapter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.stream.Collectors;
+
+import org.c4marathon.assignment.domain.model.DlqEntry;
+import org.c4marathon.assignment.domain.model.DlqStatus;
+import org.c4marathon.assignment.domain.port.DlqEntryPublisherPort;
+import org.c4marathon.assignment.domain.port.DlqEntryStoragePort;
+import org.c4marathon.assignment.pagination.PageRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DlqEntryPQAdapter implements DlqEntryPublisherPort {
+
+	private final DlqEntryStoragePort dlqEntryStoragePort;
+
+	private final PriorityBlockingQueue<DlqEntry> inMemoryDlq;
+
+	public DlqEntryPQAdapter(DlqEntryStoragePort dlqEntryStoragePort) {
+		this.dlqEntryStoragePort = dlqEntryStoragePort;
+		// PriorityBlockingQueue는 DlqEntry의 비교 기준이 필요합니다.
+		// 여기서는 nextRetryAt을 기준으로 우선순위를 정하도록 하겠습니다.
+		this.inMemoryDlq = new PriorityBlockingQueue<>(
+			101,
+			(e1, e2) -> {
+				if (e1.getNextRetryAt() == null && e2.getNextRetryAt() == null) return 0;
+				if (e1.getNextRetryAt() == null) return 1; // null은 나중에 처리
+				if (e2.getNextRetryAt() == null) return -1; // null은 나중에 처리
+				return e1.getNextRetryAt().compareTo(e2.getNextRetryAt());
+			}
+		);
+
+		// 애플리케이션 시작 시 DB에 있는 PENDING 상태의 DLQ 엔트리를 인메모리 큐에 로드
+		loadPendingEntriesFromDbToMemory();
+	}
+
+	public List<DlqEntry> findPendingCreateTransferLogEntries(int limit) {
+		LocalDateTime now = LocalDateTime.now();
+		return inMemoryDlq.stream()
+			.filter(e -> e.getStatus() == DlqStatus.PENDING && e.getOperationType().equals("CREATE_TRANSFER_LOG") && (e.getNextRetryAt() == null || e.getNextRetryAt().isBefore(now) || e.getNextRetryAt().isEqual(now)))
+			.limit(limit)
+			.collect(Collectors.toList());
+	}
+
+	@Override
+	public void offer(DlqEntry savedEntity) {
+		inMemoryDlq.offer(savedEntity);
+	}
+
+	@Override
+	public void removeIf(DlqEntry entry) {
+		// 인메모리 큐에서도 업데이트 (기존 엔트리 제거 후 새 엔트리 추가)
+		inMemoryDlq.removeIf(e -> e.getId().equals(entry.getId()));
+	}
+
+	@Override
+	public int size() {
+		return inMemoryDlq.size();
+	}
+
+	// 애플리케이션 시작 시 DB에 있는 PENDING 상태의 DLQ 엔트리를 인메모리 큐에 로드
+	private void loadPendingEntriesFromDbToMemory() {
+		List<DlqEntry> pendingEntities = dlqEntryStoragePort.findByStatusOrderByFailedAtAsc(DlqStatus.PENDING, PageRequest.of(0, 1000)); // 초기 로드 개수 제한
+		pendingEntities.forEach(inMemoryDlq::offer);
+	}
+}

--- a/dlq-infra/src/main/java/org/c4marathon/assignment/infra/adapter/DlqEntryPQAdapter.java
+++ b/dlq-infra/src/main/java/org/c4marathon/assignment/infra/adapter/DlqEntryPQAdapter.java
@@ -51,7 +51,7 @@ public class DlqEntryPQAdapter implements DlqEntryPublisherPort {
 	}
 
 	@Override
-	public void removeIf(DlqEntry entry) {
+	public void replaceById(DlqEntry entry) {
 		// 인메모리 큐에서도 업데이트 (기존 엔트리 제거 후 새 엔트리 추가)
 		inMemoryDlq.removeIf(e -> e.getId().equals(entry.getId()));
 	}

--- a/dlq-infra/src/main/java/org/c4marathon/assignment/infra/persistence/entity/DlqEntryJpaEntity.java
+++ b/dlq-infra/src/main/java/org/c4marathon/assignment/infra/persistence/entity/DlqEntryJpaEntity.java
@@ -1,0 +1,65 @@
+package org.c4marathon.assignment.infra.persistence.entity;
+
+import java.time.LocalDateTime;
+
+import org.c4marathon.assignment.domain.model.DlqEntry;
+import org.c4marathon.assignment.domain.model.DlqStatus;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "dlq_entry")
+@Getter
+@Setter
+@NoArgsConstructor
+public class DlqEntryJpaEntity {
+
+    @Id
+    private String id;
+
+    @Column(nullable = false)
+    private String operationType;
+
+    @Lob // Large Object, 긴 문자열 저장을 위해 사용
+    @Column(nullable = false)
+    private String payload;
+
+    @Lob
+    private String failureReason;
+
+    @Column(nullable = false)
+    private LocalDateTime failedAt;
+
+    @Column(nullable = false)
+    private int retryCount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DlqStatus status;
+
+    private LocalDateTime nextRetryAt; // New field
+
+    public DlqEntryJpaEntity(DlqEntry dlqEntry) {
+        this.id = dlqEntry.getId();
+        this.operationType = dlqEntry.getOperationType();
+        this.payload = dlqEntry.getPayload();
+        this.failureReason = dlqEntry.getFailureReason();
+        this.failedAt = dlqEntry.getFailedAt();
+        this.retryCount = dlqEntry.getRetryCount();
+        this.status = dlqEntry.getStatus();
+        this.nextRetryAt = dlqEntry.getNextRetryAt();
+    }
+
+    public DlqEntry toDomain() {
+        return new DlqEntry(id, operationType, payload, failureReason, failedAt, retryCount, status, nextRetryAt);
+    }
+}

--- a/dlq-infra/src/main/java/org/c4marathon/assignment/infra/persistence/repository/jpa/JpaDlqEntryRepository.java
+++ b/dlq-infra/src/main/java/org/c4marathon/assignment/infra/persistence/repository/jpa/JpaDlqEntryRepository.java
@@ -1,0 +1,14 @@
+package org.c4marathon.assignment.infra.persistence.repository.jpa;
+
+import java.util.List;
+
+import org.c4marathon.assignment.infra.persistence.entity.DlqEntryJpaEntity;
+import org.c4marathon.assignment.domain.model.DlqStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JpaDlqEntryRepository extends JpaRepository<DlqEntryJpaEntity, String> {
+    List<DlqEntryJpaEntity> findByStatusOrderByFailedAtAsc(DlqStatus status, Pageable pageable);
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,6 +34,9 @@ mapstructVersion=1.5.5.Final
 # Jackson
 jacksonVersion=2.19.0
 
+# Slack
+slackVersion = 1.45.3
+
 # JUnit
 junitJupiterVersion=5.9.2
 junitPlatformLauncherVersion=1.9.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ slf4jVersion=2.0.17
 mapstructVersion=1.5.5.Final
 
 # Jackson
-jacksonVersion=2.15.3
+jacksonVersion=2.19.0
 
 # JUnit
 junitJupiterVersion=5.9.2

--- a/interface/src/main/java/org/c4marathon/assignment/api/dlq/DlqController.java
+++ b/interface/src/main/java/org/c4marathon/assignment/api/dlq/DlqController.java
@@ -1,0 +1,39 @@
+package org.c4marathon.assignment.api.dlq;
+
+import java.util.Map;
+
+import org.c4marathon.assignment.usecase.dlq.DlqUsecase;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "DLQ API", description = "DLQ 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/dlq")
+public class DlqController {
+
+    private final DlqUsecase dlqUsecase;
+
+    @Operation(summary = "DLQ 메시지 수 조회", description = "지정된 DLQ의 메시지 수를 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "DLQ 메시지 수 조회 성공",
+            content = @Content(schema = @Schema(implementation = Map.class)))
+    })
+    @GetMapping("/messages/count")
+    public ResponseEntity<org.c4marathon.assignment.response.ApiResponse<Long>> getDlqMessageCount() {
+        long messageCount = dlqUsecase.getMQSize();
+
+		return ResponseEntity.ok(
+			org.c4marathon.assignment.response.ApiResponse.res(200, "DLQ 메시지 수 조회 성공", messageCount));
+    }
+}

--- a/interface/src/main/java/org/c4marathon/assignment/usecase/dlq/DlqUsecase.java
+++ b/interface/src/main/java/org/c4marathon/assignment/usecase/dlq/DlqUsecase.java
@@ -31,7 +31,6 @@ public class DlqUsecase {
 		String payload = objectMapper.writeValueAsString(transferLog);
 		DlqEntry dlqEntry = new DlqEntry("CREATE_TRANSFER_LOG", payload, e.getMessage());
 		dlqEntryService.save(dlqEntry);
-		log.info("DLQ에 송금 이력 작업 추가 완료: {}", dlqEntry.getId());
 	}
 
 	/**

--- a/interface/src/main/java/org/c4marathon/assignment/usecase/dlq/DlqUsecase.java
+++ b/interface/src/main/java/org/c4marathon/assignment/usecase/dlq/DlqUsecase.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.c4marathon.assignment.domain.model.DlqEntry;
 import org.c4marathon.assignment.domain.model.TransferLog;
 import org.c4marathon.assignment.domain.service.DlqEntryService;
+import org.c4marathon.assignment.domain.service.SlackService;
 import org.c4marathon.assignment.domain.service.TransferLogService;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +24,7 @@ public class DlqUsecase {
 	private final static int MAX_RETRIES = 3;
 
 	private final DlqEntryService dlqEntryService;
+	private final SlackService slackService;
 	private final ObjectMapper objectMapper;
 	private final TransferLogService transferLogService;
 
@@ -46,16 +48,21 @@ public class DlqUsecase {
 		return pendingEntries.size();
 	}
 
-	@Transactional(readOnly = true)
 	public int getMQSize() {
 		return dlqEntryService.getMQSize();
 	}
 
+	public void checkDlqMessageCount(int dlqThreshold) {
+		long currentMessageCount = dlqEntryService.getMQSize();
+
+        if (currentMessageCount > dlqThreshold) {
+			log.warn("DLQ 메시지 수 임계 값({})를 초과했습니다 . 현재 메시지 수: {}", dlqThreshold, currentMessageCount);
+			slackService.sendSlackNotification(dlqThreshold, currentMessageCount);
+		}
+	}
+
 	private void processSingleDlqEntry(DlqEntry entry) {
 		try {
-			log.info("DLQ 엔트리 처리 중: ID = {}, Operation = {}, RetryCount = {}",
-				entry.getId(), entry.getOperationType(), entry.getRetryCount());
-
 			// 재시도 횟수 초과 시 영구 실패 처리
 			if (entry.getRetryCount() >= MAX_RETRIES) {
 				entry.markAsFailed();

--- a/interface/src/main/java/org/c4marathon/assignment/usecase/dlq/DlqUsecase.java
+++ b/interface/src/main/java/org/c4marathon/assignment/usecase/dlq/DlqUsecase.java
@@ -1,5 +1,7 @@
 package org.c4marathon.assignment.usecase.dlq;
 
+import static org.springframework.transaction.annotation.Propagation.*;
+
 import java.util.List;
 
 import org.c4marathon.assignment.domain.model.DlqEntry;
@@ -28,11 +30,17 @@ public class DlqUsecase {
 	private final ObjectMapper objectMapper;
 	private final TransferLogService transferLogService;
 
-	@Transactional
-	public void saveDLQ(Exception e, TransferLog transferLog) throws JsonProcessingException {
-		String payload = objectMapper.writeValueAsString(transferLog);
-		DlqEntry dlqEntry = new DlqEntry("CREATE_TRANSFER_LOG", payload, e.getMessage());
-		dlqEntryService.save(dlqEntry);
+	@Transactional(propagation = REQUIRES_NEW)
+	public void saveDLQ(Exception e, TransferLog transferLog) {
+		try {
+			String payload = objectMapper.writeValueAsString(transferLog);
+			DlqEntry dlqEntry = new DlqEntry("CREATE_TRANSFER_LOG", payload, e.getMessage());
+			dlqEntryService.save(dlqEntry);
+		} catch (Exception dlqException) {
+			// DLQ 저장 실패는 복구 불가능한 심각한 오류이므로, 강력하게 전파
+			log.error("CRITICAL: DLQ 저장 최종 실패. 데이터 유실 가능성 높음.", dlqException);
+			throw new RuntimeException("DLQ 저장에 실패하여 데이터가 유실될 수 있습니다.", dlqException);
+		}
 	}
 
 	/**
@@ -55,7 +63,7 @@ public class DlqUsecase {
 	public void checkDlqMessageCount(int dlqThreshold) {
 		long currentMessageCount = dlqEntryService.getMQSize();
 
-        if (currentMessageCount > dlqThreshold) {
+		if (currentMessageCount > dlqThreshold) {
 			log.warn("DLQ 메시지 수 임계 값({})를 초과했습니다 . 현재 메시지 수: {}", dlqThreshold, currentMessageCount);
 			slackService.sendSlackNotification(dlqThreshold, currentMessageCount);
 		}

--- a/interface/src/main/java/org/c4marathon/assignment/usecase/dlq/DlqUsecase.java
+++ b/interface/src/main/java/org/c4marathon/assignment/usecase/dlq/DlqUsecase.java
@@ -1,0 +1,100 @@
+package org.c4marathon.assignment.usecase.dlq;
+
+import java.util.List;
+
+import org.c4marathon.assignment.domain.model.DlqEntry;
+import org.c4marathon.assignment.domain.model.TransferLog;
+import org.c4marathon.assignment.domain.service.DlqEntryService;
+import org.c4marathon.assignment.domain.service.TransferLogService;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DlqUsecase {
+
+	private final static int MAX_RETRIES = 3;
+
+	private final DlqEntryService dlqEntryService;
+	private final ObjectMapper objectMapper;
+	private final TransferLogService transferLogService;
+
+	@Transactional
+	public void saveDLQ(Exception e, TransferLog transferLog) throws JsonProcessingException {
+		String payload = objectMapper.writeValueAsString(transferLog);
+		DlqEntry dlqEntry = new DlqEntry("CREATE_TRANSFER_LOG", payload, e.getMessage());
+		dlqEntryService.save(dlqEntry);
+		log.info("DLQ에 송금 이력 작업 추가 완료: {}", dlqEntry.getId());
+	}
+
+	/**
+	 * PENDING 상태의 DLQ 엔트리를 limit개씩 가져와 처리
+	 */
+	@Transactional
+	public int processDlqBatch(int limit) {
+		List<DlqEntry> pendingEntries = dlqEntryService.findPendingCreateTransferLogEntries(limit);
+		if (pendingEntries.isEmpty()) {
+			return 0;
+		}
+		pendingEntries.forEach(this::processSingleDlqEntry);
+		return pendingEntries.size();
+	}
+
+	@Transactional(readOnly = true)
+	public int getMQSize() {
+		return dlqEntryService.getMQSize();
+	}
+
+	private void processSingleDlqEntry(DlqEntry entry) {
+		try {
+			log.info("DLQ 엔트리 처리 중: ID = {}, Operation = {}, RetryCount = {}",
+				entry.getId(), entry.getOperationType(), entry.getRetryCount());
+
+			// 재시도 횟수 초과 시 영구 실패 처리
+			if (entry.getRetryCount() >= MAX_RETRIES) {
+				entry.markAsFailed();
+				dlqEntryService.markAsProcessedAndCleanUp(entry);
+				log.warn("DLQ 엔트리 재시도 횟수 초과, 영구 실패 처리: ID = {}", entry.getId());
+				return;
+			}
+
+			entry.markAsProcessing();
+			dlqEntryService.update(entry);
+
+			if ("CREATE_TRANSFER_LOG".equals(entry.getOperationType())) {
+				try {
+					// payload를 TransferLog 객체로 역직렬화
+					TransferLog transferLog = objectMapper.readValue(entry.getPayload(), TransferLog.class);
+					transferLogService.saveTransferLog(transferLog);
+					log.info("송금 이력 생성 재시도 성공: Payload = {}", entry.getPayload());
+					entry.markAsSuccess();
+					dlqEntryService.markAsProcessedAndCleanUp(entry);
+				} catch (JsonProcessingException e) {
+					log.error("TransferLog 역직렬화 실패: {}", e.getMessage(), e);
+					entry.markAsFailed();
+					dlqEntryService.markAsProcessedAndCleanUp(entry);
+				}
+			} else {
+				log.warn("알 수 없는 DLQ Operation Type: {}", entry.getOperationType());
+				entry.markAsFailed();
+				dlqEntryService.markAsProcessedAndCleanUp(entry);
+			}
+
+			log.info("DLQ 엔트리 처리 완료: ID = {}", entry.getId());
+
+		} catch (Exception e) {
+			log.error("DLQ 엔트리 처리 중 오류 발생: ID = {}, Error = {}", entry.getId(), e.getMessage(), e);
+			entry.incrementRetryCount();
+			entry.calculateNextRetryTime();
+			entry.markAsPending();
+			dlqEntryService.markAsProcessedAndCleanUp(entry);
+		}
+	}
+}

--- a/interface/src/main/java/org/c4marathon/assignment/usecase/transfer/PendingTransferUseCase.java
+++ b/interface/src/main/java/org/c4marathon/assignment/usecase/transfer/PendingTransferUseCase.java
@@ -110,26 +110,30 @@ public class PendingTransferUseCase {
 
 	// todo: 보상 로직 만들기 (DLQ)
 	@Transactional
-	public void expirePendingTransfer() {
-		List<PendingTransfer> expiredPendingTransfers = pendingTransferService.findRemindPendingTransferWithMainAccount();
-
+	public void expirePendingTransferList() {
+		List<PendingTransfer> expiredPendingTransfers = pendingTransferService.findExpirablePendingTransfersWithMember();
 		for (PendingTransfer tx : expiredPendingTransfers) {
-			pendingTransferService.expired(tx);
-
-			// 계좌 정보 조회
-			MainAccount fromAccount = mainAccountService.findById(tx.getFromMainAccountId());
-			MainAccount toAccount = mainAccountService.findById(tx.getToMainAccountId());
-
-			TransferLog transferLog = transferLogFactory.createExpirePendingTransferLog(
-					tx.getId(),
-					fromAccount,
-					toAccount,
-					tx.getAmount(),
-					tx.getCreatedAt());
-			transferLogService.saveTransferLog(transferLog);
+			expirePendingTransfer(tx);
 		}
 	}
 
+	public void expirePendingTransfer(PendingTransfer tx) {
+		// 계좌 정보 조회
+		MainAccount fromAccount = mainAccountService.findById(tx.getFromMainAccountId());
+		MainAccount toAccount = mainAccountService.findById(tx.getToMainAccountId());
+
+		retryExecutor.executeWithRetry(() -> pendingTransferService.expired(tx));
+
+		TransferLog transferLog = transferLogFactory.createExpirePendingTransferLog(
+				tx.getId(),
+				fromAccount,
+				toAccount,
+				tx.getAmount(),
+				tx.getCreatedAt());
+		transferLogService.saveTransferLog(transferLog);
+	}
+
+	@Transactional(readOnly = true)
 	public void remindPendingTargetTransactionsByImproved() {
 		Map<Member, List<PendingTransfer>> remindTargetGroupedByMember = pendingTransferService.findRemindTargetGroupedByMember();
 		reminderService.remindTransactions(remindTargetGroupedByMember);

--- a/interface/src/main/java/org/c4marathon/assignment/usecase/transfer/TransferUseCase.java
+++ b/interface/src/main/java/org/c4marathon/assignment/usecase/transfer/TransferUseCase.java
@@ -14,137 +14,162 @@ import org.c4marathon.assignment.policy.ExternalAccountPolicy;
 import org.c4marathon.assignment.retry.RetryExecutor;
 import org.c4marathon.assignment.api.transfer.dto.TransferRequestDto;
 import org.c4marathon.assignment.api.transfer.dto.AccountNumberTransferRequestDto;
-import org.springframework.stereotype.Service;
+import org.c4marathon.assignment.usecase.dlq.DlqUsecase;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
 /**
  * 계좌 이체 유스케이스를 처리하는 서비스
  */
 @Slf4j
-@Service
+@Component
 @RequiredArgsConstructor
 public class TransferUseCase {
 
-	private final MainAccountService mainAccountService;
-	private final SavingAccountService savingAccountService;
-	private final TransferService transferService;
-	private final TransferLogService transferLogService;
-	private final TransferLogFactory transferLogFactory;
-	private final RetryExecutor retryExecutor;
-	private final ChargeUsecase chargeUsecase;
+	private final DlqUsecase dlqUsecase;
+    private final MainAccountService mainAccountService;
+    private final SavingAccountService savingAccountService;
+    private final TransferService transferService;
+    private final TransferLogService transferLogService;
+    private final TransferLogFactory transferLogFactory;
+    private final RetryExecutor retryExecutor;
+    private final ChargeUsecase chargeUsecase;
+    private final ObjectMapper objectMapper; // ObjectMapper 주입
 
-	/**
-	 * 계좌 ID를 기반으로 일반 계좌 간 이체를 수행합니다.
-	 */
-	@Transactional
-	public void transfer(TransferRequestDto request) {
-		final Long fromAccountId = request.fromAccountId();
-		final Long toAccountId = request.toAccountId();
-		final Long amount = request.amount();
+    /**
+     * 계좌 ID를 기반으로 일반 계좌 간 이체를 수행합니다.
+     */
+    @Transactional
+    public void transfer(TransferRequestDto request) {
+        final Long fromAccountId = request.fromAccountId();
+        final Long toAccountId = request.toAccountId();
+        final Long amount = request.amount();
 
-		// 잔액 부족 시 충전 처리
-		handleShortfall(fromAccountId, amount);
+        // 잔액 부족 시 충전 처리
+        handleShortfall(fromAccountId, amount);
 
-		// 송금 실행
-		executeMainToMainTransfer(fromAccountId, toAccountId, amount);
+        // 송금 실행
+        executeMainToMainTransfer(fromAccountId, toAccountId, amount);
+    }
+
+    /**
+     * 계좌 번호를 기반으로 일반 계좌 간 이체를 수행합니다.
+     */
+    @Transactional
+    public void transferByAccountNumber(AccountNumberTransferRequestDto request) {
+        // 계좌번호로 계좌 조회 및 검증
+        MainAccount fromAccount = mainAccountService.findByAccountNumberOrThrow(request.fromAccountNumber());
+        MainAccount toAccount = mainAccountService.findByAccountNumberOrThrow(request.toAccountNumber());
+        final Long amount = request.amount();
+
+        // 잔액 부족 확인 및 필요시 충전
+        handleShortfall(fromAccount.getId(), amount);
+
+        // 송금 실행
+        executeMainToMainTransfer(fromAccount.getId(), toAccount.getId(), amount);
+    }
+
+    /**
+     * 계좌 번호를 기반으로 일반 계좌에서 적금 계좌로 이체를 수행합니다.
+     */
+    @Transactional
+    public void transferFromMainToSavingByAccountNumber(AccountNumberTransferRequestDto request) {
+        // 계좌번호로 계좌 조회 및 검증
+        MainAccount fromAccount = mainAccountService.findByAccountNumberOrThrow(request.fromAccountNumber());
+        SavingAccount toAccount = savingAccountService.findByAccountNumberOrThrow(request.toAccountNumber());
+        final Long amount = request.amount();
+
+        // 잔액 부족 확인 및 필요시 충전
+        handleShortfall(fromAccount.getId(), amount);
+
+        // 송금 실행
+        executeMainToSavingTransfer(fromAccount.getId(), toAccount.getId(), amount);
+    }
+
+    /**
+     * 잔액 부족 시 충전을 처리하는 메서드
+     */
+    private void handleShortfall(Long accountId, Long amount) {
+        Long shortfall = mainAccountService.calculateShortfall(accountId, amount);
+
+        if (shortfall > 0) {
+            chargeUsecase.charge(accountId, shortfall, amount);
+
+            MainAccount refreshedAccount = mainAccountService.findById(accountId);
+            TransferLog transferLog = transferLogFactory.createExternalChargeLog(
+                ExternalAccountPolicy.TEMPORARY_CHARGING, refreshedAccount, shortfall);
+            transferLogService.saveTransferLog(transferLog);
+        }
+    }
+
+    /**
+     * 일반 계좌 간(MainAccount -> MainAccount) 송금을 실행합니다.
+     */
+    private void executeMainToMainTransfer(Long fromAccountId, Long toAccountId, Long amount) {
+        MainAccount refreshedFromAccount = mainAccountService.findById(fromAccountId);
+        MainAccount refreshedToAccount = mainAccountService.findById(toAccountId);
+
+        // 송금 실행 (재시도 로직 포함)
+        retryExecutor.executeWithRetry(() -> {
+            transferService.transfer(refreshedFromAccount, refreshedToAccount, amount);
+            log.debug("일반 계좌 간 송금 완료: {} -> {}, 금액: {}",
+                refreshedFromAccount.getAccountNumber(),
+                refreshedToAccount.getAccountNumber(),
+                amount);
+            return true;
+        });
+
+        // 송금 성공 시 로그 생성
+        TransferLog transferLog = transferLogFactory.createImmediateTransferLog(
+            refreshedFromAccount, refreshedToAccount, amount);
+
+		saveTransferLogFailureToDlq(transferLog);
 	}
 
 	/**
-	 * 계좌 번호를 기반으로 일반 계좌 간 이체를 수행합니다.
-	 */
-	@Transactional
-	public void transferByAccountNumber(AccountNumberTransferRequestDto request) {
-		// 계좌번호로 계좌 조회 및 검증
-		MainAccount fromAccount = mainAccountService.findByAccountNumberOrThrow(request.fromAccountNumber());
-		MainAccount toAccount = mainAccountService.findByAccountNumberOrThrow(request.toAccountNumber());
-		final Long amount = request.amount();
+     * 일반 계좌에서 적금 계좌로(MainAccount -> SavingAccount) 송금을 실행합니다.
+     */
+    private void executeMainToSavingTransfer(Long fromAccountId, Long toAccountId, Long amount) {
+        MainAccount refreshedFromAccount = mainAccountService.findById(fromAccountId);
+        SavingAccount refreshedToAccount = savingAccountService.findById(toAccountId);
 
-		// 잔액 부족 확인 및 필요시 충전
-		handleShortfall(fromAccount.getId(), amount);
+        // 송금 실행 (재시도 로직 포함)
+        retryExecutor.executeWithRetry(() -> {
+            transferService.transfer(refreshedFromAccount, refreshedToAccount, amount);
+            log.debug("일반 계좌에서 적금 계좌로 송금 완료: {} -> {}, 금액: {}",
+                refreshedFromAccount.getAccountNumber(),
+                refreshedToAccount.getAccountNumber(),
+                amount);
+            return true;
+        });
 
-		// 송금 실행
-		executeMainToMainTransfer(fromAccount.getId(), toAccount.getId(), amount);
+        // 송금 성공 시 로그 생성
+        TransferLog transferLog = transferLogFactory.createImmediateTransferLog(
+            refreshedFromAccount, refreshedToAccount, amount);
+
+		saveTransferLogFailureToDlq(transferLog);
 	}
 
-	/**
-	 * 계좌 번호를 기반으로 일반 계좌에서 적금 계좌로 이체를 수행합니다.
-	 */
-	@Transactional
-	public void transferFromMainToSavingByAccountNumber(AccountNumberTransferRequestDto request) {
-		// 계좌번호로 계좌 조회 및 검증
-		MainAccount fromAccount = mainAccountService.findByAccountNumberOrThrow(request.fromAccountNumber());
-		SavingAccount toAccount = savingAccountService.findByAccountNumberOrThrow(request.toAccountNumber());
-		final Long amount = request.amount();
-
-		// 잔액 부족 확인 및 필요시 충전
-		handleShortfall(fromAccount.getId(), amount);
-
-		// 송금 실행
-		executeMainToSavingTransfer(fromAccount.getId(), toAccount.getId(), amount);
-	}
-
-	/**
-	 * 잔액 부족 시 충전을 처리하는 메서드
-	 */
-	private void handleShortfall(Long accountId, Long amount) {
-		Long shortfall = mainAccountService.calculateShortfall(accountId, amount);
-
-		if (shortfall > 0) {
-			chargeUsecase.charge(accountId, shortfall, amount);
-
-			MainAccount refreshedAccount = mainAccountService.findById(accountId);
-			TransferLog transferLog = transferLogFactory.createExternalChargeLog(
-				ExternalAccountPolicy.TEMPORARY_CHARGING, refreshedAccount, shortfall);
-			transferLogService.saveTransferLog(transferLog);
+	private void saveTransferLogFailureToDlq(TransferLog transferLog) {
+		try {
+			throw new RuntimeException("의도적인 예외");
+			// transferLogService.saveTransferLog(transferLog);
+		} catch (Exception e) {
+			log.error("송금 이력 저장 실패, DLQ에 추가: {}", e.getMessage(), e);
+			try {
+				// TransferLog 객체를 JSON 문자열로 변환하여 payload에 저장
+				dlqUsecase.saveDLQ(e, transferLog);
+			} catch (JsonProcessingException jsonException) {
+				log.error("DLQ payload 직렬화 실패: {}", jsonException.getMessage(), jsonException);
+				// 이 경우 DLQ에도 저장할 수 없으므로, 별도의 알림 또는 로깅 필요
+			}
 		}
 	}
 
-	/**
-	 * 일반 계좌 간(MainAccount -> MainAccount) 송금을 실행합니다.
-	 */
-	private void executeMainToMainTransfer(Long fromAccountId, Long toAccountId, Long amount) {
-		MainAccount refreshedFromAccount = mainAccountService.findById(fromAccountId);
-		MainAccount refreshedToAccount = mainAccountService.findById(toAccountId);
-
-		// 송금 실행 (재시도 로직 포함)
-		retryExecutor.executeWithRetry(() -> {
-			transferService.transfer(refreshedFromAccount, refreshedToAccount, amount);
-			log.debug("일반 계좌 간 송금 완료: {} -> {}, 금액: {}",
-				refreshedFromAccount.getAccountNumber(),
-				refreshedToAccount.getAccountNumber(),
-				amount);
-			return true;
-		});
-
-		// 송금 성공 시 로그 생성
-		TransferLog transferLog = transferLogFactory.createImmediateTransferLog(
-			refreshedFromAccount, refreshedToAccount, amount);
-		transferLogService.saveTransferLog(transferLog);
-	}
-
-	/**
-	 * 일반 계좌에서 적금 계좌로(MainAccount -> SavingAccount) 송금을 실행합니다.
-	 */
-	private void executeMainToSavingTransfer(Long fromAccountId, Long toAccountId, Long amount) {
-		MainAccount refreshedFromAccount = mainAccountService.findById(fromAccountId);
-		SavingAccount refreshedToAccount = savingAccountService.findById(toAccountId);
-
-		// 송금 실행 (재시도 로직 포함)
-		retryExecutor.executeWithRetry(() -> {
-			transferService.transfer(refreshedFromAccount, refreshedToAccount, amount);
-			log.debug("일반 계좌에서 적금 계좌로 송금 완료: {} -> {}, 금액: {}",
-				refreshedFromAccount.getAccountNumber(),
-				refreshedToAccount.getAccountNumber(),
-				amount);
-			return true;
-		});
-
-		// 송금 성공 시 로그 생성
-		TransferLog transferLog = transferLogFactory.createImmediateTransferLog(
-			refreshedFromAccount, refreshedToAccount, amount);
-		transferLogService.saveTransferLog(transferLog);
-	}
 }

--- a/interface/src/main/java/org/c4marathon/assignment/usecase/transfer/TransferUseCase.java
+++ b/interface/src/main/java/org/c4marathon/assignment/usecase/transfer/TransferUseCase.java
@@ -158,8 +158,7 @@ public class TransferUseCase {
 
 	private void saveTransferLogFailureToDlq(TransferLog transferLog) {
 		try {
-			throw new RuntimeException("의도적인 예외");
-			// transferLogService.saveTransferLog(transferLog);
+			transferLogService.saveTransferLog(transferLog);
 		} catch (Exception e) {
 			log.error("송금 이력 저장 실패, DLQ에 추가: {}", e.getMessage(), e);
 			try {
@@ -171,5 +170,4 @@ public class TransferUseCase {
 			}
 		}
 	}
-
 }

--- a/interface/src/main/java/org/c4marathon/assignment/usecase/transfer/TransferUseCase.java
+++ b/interface/src/main/java/org/c4marathon/assignment/usecase/transfer/TransferUseCase.java
@@ -21,9 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.core.JsonProcessingException;
-
 /**
  * 계좌 이체 유스케이스를 처리하는 서비스
  */
@@ -33,125 +30,124 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 public class TransferUseCase {
 
 	private final DlqUsecase dlqUsecase;
-    private final MainAccountService mainAccountService;
-    private final SavingAccountService savingAccountService;
-    private final TransferService transferService;
-    private final TransferLogService transferLogService;
-    private final TransferLogFactory transferLogFactory;
-    private final RetryExecutor retryExecutor;
-    private final ChargeUsecase chargeUsecase;
-    private final ObjectMapper objectMapper; // ObjectMapper 주입
+	private final MainAccountService mainAccountService;
+	private final SavingAccountService savingAccountService;
+	private final TransferService transferService;
+	private final TransferLogService transferLogService;
+	private final TransferLogFactory transferLogFactory;
+	private final RetryExecutor retryExecutor;
+	private final ChargeUsecase chargeUsecase;
 
-    /**
-     * 계좌 ID를 기반으로 일반 계좌 간 이체를 수행합니다.
-     */
-    @Transactional
-    public void transfer(TransferRequestDto request) {
-        final Long fromAccountId = request.fromAccountId();
-        final Long toAccountId = request.toAccountId();
-        final Long amount = request.amount();
+	/**
+	 * 계좌 ID를 기반으로 일반 계좌 간 이체를 수행합니다.
+	 */
+	@Transactional
+	public void transfer(TransferRequestDto request) {
+		final Long fromAccountId = request.fromAccountId();
+		final Long toAccountId = request.toAccountId();
+		final Long amount = request.amount();
 
-        // 잔액 부족 시 충전 처리
-        handleShortfall(fromAccountId, amount);
+		// 잔액 부족 시 충전 처리
+		handleShortfall(fromAccountId, amount);
 
-        // 송금 실행
-        executeMainToMainTransfer(fromAccountId, toAccountId, amount);
-    }
+		// 송금 실행
+		executeMainToMainTransfer(fromAccountId, toAccountId, amount);
+	}
 
-    /**
-     * 계좌 번호를 기반으로 일반 계좌 간 이체를 수행합니다.
-     */
-    @Transactional
-    public void transferByAccountNumber(AccountNumberTransferRequestDto request) {
-        // 계좌번호로 계좌 조회 및 검증
-        MainAccount fromAccount = mainAccountService.findByAccountNumberOrThrow(request.fromAccountNumber());
-        MainAccount toAccount = mainAccountService.findByAccountNumberOrThrow(request.toAccountNumber());
-        final Long amount = request.amount();
+	/**
+	 * 계좌 번호를 기반으로 일반 계좌 간 이체를 수행합니다.
+	 */
+	@Transactional
+	public void transferByAccountNumber(AccountNumberTransferRequestDto request) {
+		// 계좌번호로 계좌 조회 및 검증
+		MainAccount fromAccount = mainAccountService.findByAccountNumberOrThrow(request.fromAccountNumber());
+		MainAccount toAccount = mainAccountService.findByAccountNumberOrThrow(request.toAccountNumber());
+		final Long amount = request.amount();
 
-        // 잔액 부족 확인 및 필요시 충전
-        handleShortfall(fromAccount.getId(), amount);
+		// 잔액 부족 확인 및 필요시 충전
+		handleShortfall(fromAccount.getId(), amount);
 
-        // 송금 실행
-        executeMainToMainTransfer(fromAccount.getId(), toAccount.getId(), amount);
-    }
+		// 송금 실행
+		executeMainToMainTransfer(fromAccount.getId(), toAccount.getId(), amount);
+	}
 
-    /**
-     * 계좌 번호를 기반으로 일반 계좌에서 적금 계좌로 이체를 수행합니다.
-     */
-    @Transactional
-    public void transferFromMainToSavingByAccountNumber(AccountNumberTransferRequestDto request) {
-        // 계좌번호로 계좌 조회 및 검증
-        MainAccount fromAccount = mainAccountService.findByAccountNumberOrThrow(request.fromAccountNumber());
-        SavingAccount toAccount = savingAccountService.findByAccountNumberOrThrow(request.toAccountNumber());
-        final Long amount = request.amount();
+	/**
+	 * 계좌 번호를 기반으로 일반 계좌에서 적금 계좌로 이체를 수행합니다.
+	 */
+	@Transactional
+	public void transferFromMainToSavingByAccountNumber(AccountNumberTransferRequestDto request) {
+		// 계좌번호로 계좌 조회 및 검증
+		MainAccount fromAccount = mainAccountService.findByAccountNumberOrThrow(request.fromAccountNumber());
+		SavingAccount toAccount = savingAccountService.findByAccountNumberOrThrow(request.toAccountNumber());
+		final Long amount = request.amount();
 
-        // 잔액 부족 확인 및 필요시 충전
-        handleShortfall(fromAccount.getId(), amount);
+		// 잔액 부족 확인 및 필요시 충전
+		handleShortfall(fromAccount.getId(), amount);
 
-        // 송금 실행
-        executeMainToSavingTransfer(fromAccount.getId(), toAccount.getId(), amount);
-    }
+		// 송금 실행
+		executeMainToSavingTransfer(fromAccount.getId(), toAccount.getId(), amount);
+	}
 
-    /**
-     * 잔액 부족 시 충전을 처리하는 메서드
-     */
-    private void handleShortfall(Long accountId, Long amount) {
-        Long shortfall = mainAccountService.calculateShortfall(accountId, amount);
+	/**
+	 * 잔액 부족 시 충전을 처리하는 메서드
+	 */
+	private void handleShortfall(Long accountId, Long amount) {
+		Long shortfall = mainAccountService.calculateShortfall(accountId, amount);
 
-        if (shortfall > 0) {
-            chargeUsecase.charge(accountId, shortfall, amount);
+		if (shortfall > 0) {
+			chargeUsecase.charge(accountId, shortfall, amount);
 
-            MainAccount refreshedAccount = mainAccountService.findById(accountId);
-            TransferLog transferLog = transferLogFactory.createExternalChargeLog(
-                ExternalAccountPolicy.TEMPORARY_CHARGING, refreshedAccount, shortfall);
-            transferLogService.saveTransferLog(transferLog);
-        }
-    }
+			MainAccount refreshedAccount = mainAccountService.findById(accountId);
+			TransferLog transferLog = transferLogFactory.createExternalChargeLog(
+				ExternalAccountPolicy.TEMPORARY_CHARGING, refreshedAccount, shortfall);
+			transferLogService.saveTransferLog(transferLog);
+		}
+	}
 
-    /**
-     * 일반 계좌 간(MainAccount -> MainAccount) 송금을 실행합니다.
-     */
-    private void executeMainToMainTransfer(Long fromAccountId, Long toAccountId, Long amount) {
-        MainAccount refreshedFromAccount = mainAccountService.findById(fromAccountId);
-        MainAccount refreshedToAccount = mainAccountService.findById(toAccountId);
+	/**
+	 * 일반 계좌 간(MainAccount -> MainAccount) 송금을 실행합니다.
+	 */
+	private void executeMainToMainTransfer(Long fromAccountId, Long toAccountId, Long amount) {
+		MainAccount refreshedFromAccount = mainAccountService.findById(fromAccountId);
+		MainAccount refreshedToAccount = mainAccountService.findById(toAccountId);
 
-        // 송금 실행 (재시도 로직 포함)
-        retryExecutor.executeWithRetry(() -> {
-            transferService.transfer(refreshedFromAccount, refreshedToAccount, amount);
-            log.debug("일반 계좌 간 송금 완료: {} -> {}, 금액: {}",
-                refreshedFromAccount.getAccountNumber(),
-                refreshedToAccount.getAccountNumber(),
-                amount);
-            return true;
-        });
+		// 송금 실행 (재시도 로직 포함)
+		retryExecutor.executeWithRetry(() -> {
+			transferService.transfer(refreshedFromAccount, refreshedToAccount, amount);
+			log.debug("일반 계좌 간 송금 완료: {} -> {}, 금액: {}",
+				refreshedFromAccount.getAccountNumber(),
+				refreshedToAccount.getAccountNumber(),
+				amount);
+			return true;
+		});
 
-        // 송금 성공 시 로그 생성
-        TransferLog transferLog = transferLogFactory.createImmediateTransferLog(
-            refreshedFromAccount, refreshedToAccount, amount);
+		// 송금 성공 시 로그 생성
+		TransferLog transferLog = transferLogFactory.createImmediateTransferLog(
+			refreshedFromAccount, refreshedToAccount, amount);
 
 		saveTransferLogFailureToDlq(transferLog);
 	}
 
 	/**
-     * 일반 계좌에서 적금 계좌로(MainAccount -> SavingAccount) 송금을 실행합니다.
-     */
-    private void executeMainToSavingTransfer(Long fromAccountId, Long toAccountId, Long amount) {
-        MainAccount refreshedFromAccount = mainAccountService.findById(fromAccountId);
-        SavingAccount refreshedToAccount = savingAccountService.findById(toAccountId);
+	 * 일반 계좌에서 적금 계좌로(MainAccount -> SavingAccount) 송금을 실행합니다.
+	 */
+	private void executeMainToSavingTransfer(Long fromAccountId, Long toAccountId, Long amount) {
+		MainAccount refreshedFromAccount = mainAccountService.findById(fromAccountId);
+		SavingAccount refreshedToAccount = savingAccountService.findById(toAccountId);
 
-        // 송금 실행 (재시도 로직 포함)
-        retryExecutor.executeWithRetry(() -> {
-            transferService.transfer(refreshedFromAccount, refreshedToAccount, amount);
-            log.debug("일반 계좌에서 적금 계좌로 송금 완료: {} -> {}, 금액: {}",
-                refreshedFromAccount.getAccountNumber(),
-                refreshedToAccount.getAccountNumber(),
-                amount);
-            return true;
-        });
+		// 송금 실행 (재시도 로직 포함)
+		retryExecutor.executeWithRetry(() -> {
+			transferService.transfer(refreshedFromAccount, refreshedToAccount, amount);
+			log.debug("일반 계좌에서 적금 계좌로 송금 완료: {} -> {}, 금액: {}",
+				refreshedFromAccount.getAccountNumber(),
+				refreshedToAccount.getAccountNumber(),
+				amount);
+			return true;
+		});
 
-        // 송금 성공 시 로그 생성
-        TransferLog transferLog = transferLogFactory.createImmediateTransferLog(
-            refreshedFromAccount, refreshedToAccount, amount);
+		// 송금 성공 시 로그 생성
+		TransferLog transferLog = transferLogFactory.createImmediateTransferLog(
+			refreshedFromAccount, refreshedToAccount, amount);
 
 		saveTransferLogFailureToDlq(transferLog);
 	}
@@ -164,9 +160,10 @@ public class TransferUseCase {
 			try {
 				// TransferLog 객체를 JSON 문자열로 변환하여 payload에 저장
 				dlqUsecase.saveDLQ(e, transferLog);
-			} catch (JsonProcessingException jsonException) {
-				log.error("DLQ payload 직렬화 실패: {}", jsonException.getMessage(), jsonException);
-				// 이 경우 DLQ에도 저장할 수 없으므로, 별도의 알림 또는 로깅 필요
+			} catch (Exception dlqException) {
+				log.error("CRITICAL: DLQ 저장 실패. 데이터가 유실될 수 있습니다. 원인: {}", dlqException.getMessage(), dlqException);
+				// DLQ 저장 실패는 심각한 문제이므로, 런타임 예외를 발생시켜 트랜잭션을 롤백하고 시스템에 알려야 합니다.
+				throw new RuntimeException("DLQ 저장에 실패했습니다.", dlqException);
 			}
 		}
 	}

--- a/main-account-domain/src/main/java/org/c4marathon/assignment/domain/model/MainAccount.java
+++ b/main-account-domain/src/main/java/org/c4marathon/assignment/domain/model/MainAccount.java
@@ -28,6 +28,8 @@ public class MainAccount implements Account {
 		return MainAccount.builder()
 			.accountNumber(accountNumber)
 			.memberId(memberId)
+			.balance(0L)
+			.dailyChargeAmount(0L)
 			.build();
 	}
 

--- a/main-account-domain/src/main/java/org/c4marathon/assignment/domain/service/MainAccountService.java
+++ b/main-account-domain/src/main/java/org/c4marathon/assignment/domain/service/MainAccountService.java
@@ -73,6 +73,10 @@ public class MainAccountService {
 		mainAccountRepository.resetAllDailyChargeAmount();
 	}
 
+	public int depositByOptimistic(MainAccount mainAccount, Long amount) {
+		return mainAccountRepository.depositByOptimistic(mainAccount.getId(), amount, mainAccount.getVersion());
+	}
+
 	public Long calculateShortfall(Long accountId, Long transferAmount) {
 		Long currentBalance = mainAccountRepository.findMainAccountAmountById(accountId);
 		long diff = transferAmount - currentBalance;

--- a/member-domain/src/main/java/org/c4marathon/assignment/domain/model/Member.java
+++ b/member-domain/src/main/java/org/c4marathon/assignment/domain/model/Member.java
@@ -28,4 +28,16 @@ public class Member {
         return new Member(id, name, email, password, createdAt, updatedAt);
     }
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		Member member = (Member) o;
+		return id.equals(member.id);
+	}
+
+	@Override
+	public int hashCode() {
+		return id.hashCode();
+	}
 }

--- a/reminder/src/main/java/org/c4marathon/assignment/domain/service/ReminderService.java
+++ b/reminder/src/main/java/org/c4marathon/assignment/domain/service/ReminderService.java
@@ -7,12 +7,10 @@ import org.c4marathon.assignment.domain.model.Member;
 import org.c4marathon.assignment.domain.model.PendingTransfer;
 import org.springframework.stereotype.Service;
 
-import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service
-@AllArgsConstructor
 public class ReminderService {
 
 	// public void remindTransactions(PendingTransfer transferTransaction) {
@@ -26,7 +24,7 @@ public class ReminderService {
 
 	public void remindTransactions(Map<Member, List<PendingTransfer>> grouped) {
 		grouped.forEach((member, transactions) -> {
-			log.info("[RemindGroup] Member: {} ({}건)", member.getName(), transactions.size());
+			log.info("[RemindGroup] Member ID: {}, Member: {} ({}건)", member.getId(), member.getName(), transactions.size());
 
 			transactions.forEach(tx ->
 				log.info(" - Tx ID: {}, Amount: {}, ExpiredAt: {}",

--- a/reminder/src/main/java/org/c4marathon/assignment/domain/service/SlackService.java
+++ b/reminder/src/main/java/org/c4marathon/assignment/domain/service/SlackService.java
@@ -1,0 +1,37 @@
+package org.c4marathon.assignment.domain.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.slack.api.Slack;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class SlackService {
+
+	@Value("${slack.token}")
+	private String slackToken;
+
+	@Value("${slack.channel}")
+	private String slackChannel;
+
+	public void sendSlackNotification(long dlqThreshold, long currentMessageCount) {
+		try {
+			MethodsClient methods = Slack.getInstance().methods(slackToken);
+			String message = String.format("DLQ 메시지 수는 %d의 임계 값을 초과했습니다. 현재 수 : %d", dlqThreshold, currentMessageCount);
+
+			ChatPostMessageRequest request = ChatPostMessageRequest.builder()
+				.channel(slackChannel)
+				.text(message)
+				.build();
+
+			methods.chatPostMessage(request);
+		} catch (Exception e) {
+			log.error("슬랙 알림 실패: {}", e.getMessage());
+		}
+	}
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,6 +12,7 @@ include 'main-account-infra'
 include 'saving-account-infra'
 include 'transfer-infra'
 include 'transfer-log-infra'
+include 'dlq-infra'
 
 // Domain Modules
 include 'member-domain'
@@ -20,6 +21,7 @@ include 'saving-account-domain'
 include 'transfer-domain'
 include 'transfer-log-domain'
 include 'settlement-domain'
+include 'dlq-domain'
 
 // Application Modules
 include 'interface'

--- a/transfer-domain/src/main/java/org/c4marathon/assignment/domain/repository/PendingTransferRepository.java
+++ b/transfer-domain/src/main/java/org/c4marathon/assignment/domain/repository/PendingTransferRepository.java
@@ -15,7 +15,7 @@ public interface PendingTransferRepository  {
     
     List<PendingTransfer> findRemindTargetsWithMainAccount(LocalDateTime notificationReadyCutoffTime);
     
-    List<PendingTransfer> findRemindTargetsWithMember(LocalDateTime notificationReadyCutoffTime);
+    List<PendingTransfer> findExpirablePendingTransfersWithMember(LocalDateTime notificationReadyCutoffTime);
     
     Map<Member, List<PendingTransfer>> findRemindTargetGroupedByMember(LocalDateTime notificationReadyCutoffTime);
 }

--- a/transfer-domain/src/main/java/org/c4marathon/assignment/domain/service/PendingTransferService.java
+++ b/transfer-domain/src/main/java/org/c4marathon/assignment/domain/service/PendingTransferService.java
@@ -53,12 +53,7 @@ public class PendingTransferService {
 		MainAccount toAccount = mainAccountRepository.findById(tx.getToMainAccountId())
 			.orElseThrow(() -> new IllegalArgumentException("입금 계좌가 존재하지 않습니다"));
 
-		int result = mainAccountRepository.depositByOptimistic(tx.getToMainAccountId(), tx.getAmount(),
-			toAccount.getVersion());
-
-		if (result == 0) {
-			throw new OptimisticLockException("입금 실패 - 동시성 문제");
-		}
+		depositByOptimistic(tx, toAccount);
 
 		tx.markAsCompleted();
 		pendingTransferRepository.save(tx);
@@ -72,31 +67,31 @@ public class PendingTransferService {
 		MainAccount fromAccount = mainAccountRepository.findById(tx.getFromMainAccountId())
 			.orElseThrow(() -> new IllegalArgumentException("환불 계좌가 존재하지 않습니다"));
 
-		int result = mainAccountRepository.depositByOptimistic(tx.getFromMainAccountId(), tx.getAmount(),
-			fromAccount.getVersion());
-
-		if (result == 0) {
-			throw new OptimisticLockException("환불 실패 - 동시성 문제");
-		}
+		depositByOptimistic(tx, fromAccount);
 
 		tx.markAsCanceled();
 		pendingTransferRepository.save(tx);
 		return true;
 	}
 
-	public void expired(PendingTransfer tx) {
+	public Boolean expired(PendingTransfer tx) {
 		MainAccount fromAccount = mainAccountRepository.findById(tx.getFromMainAccountId())
 			.orElseThrow(() -> new IllegalArgumentException("환불 계좌가 존재하지 않습니다"));
 
+		depositByOptimistic(tx, fromAccount);
+
+		tx.markAsExpired();
+		pendingTransferRepository.save(tx);
+		return true;
+	}
+
+	private void depositByOptimistic(PendingTransfer tx, MainAccount account) {
 		int result = mainAccountRepository.depositByOptimistic(tx.getFromMainAccountId(), tx.getAmount(),
-			fromAccount.getVersion());
+			account.getVersion());
 
 		if (result == 0) {
 			throw new OptimisticLockException("환불 실패 - 동시성 문제");
 		}
-
-		tx.markAsExpired();
-		pendingTransferRepository.save(tx);
 	}
 
 	public PendingTransfer findPendingTransfer(Long transactionId) {
@@ -111,11 +106,11 @@ public class PendingTransferService {
 		return pendingTransferRepository.findRemindTargetGroupedByMember(notificationReadyCutoffTime);
 	}
 
-	public List<PendingTransfer> findRemindPendingTargetTransactionsWithMember() {
-		Duration remindDurationHour = pendingTransferPolicy.getPendingTransferRemindDurationHours();
+	public List<PendingTransfer> findExpirablePendingTransfersWithMember() {
+		Duration remindDurationHour = pendingTransferPolicy.getPendingTransferExpireAfterDurationHours();
 		LocalDateTime notificationReadyCutoffTime = LocalDateTime.now().minus(remindDurationHour);
 
-		return pendingTransferRepository.findRemindTargetsWithMember(notificationReadyCutoffTime);
+		return pendingTransferRepository.findExpirablePendingTransfersWithMember(notificationReadyCutoffTime);
 	}
 
 	public List<PendingTransfer> findRemindPendingTransferWithMainAccount() {

--- a/transfer-infra/src/main/java/org/c4marathon/assignment/infra/persistence/repository/PendingTransferRepositoryImpl.java
+++ b/transfer-infra/src/main/java/org/c4marathon/assignment/infra/persistence/repository/PendingTransferRepositoryImpl.java
@@ -50,8 +50,8 @@ public class PendingTransferRepositoryImpl implements PendingTransferRepository 
     }
 
     @Override
-    public List<PendingTransfer> findRemindTargetsWithMember(LocalDateTime notificationReadyCutoffTime) {
-        return jpaPendingTransferRepository.findRemindPendingTargetTransactionsWithMember(notificationReadyCutoffTime).stream()
+    public List<PendingTransfer> findExpirablePendingTransfersWithMember(LocalDateTime notificationReadyCutoffTime) {
+        return jpaPendingTransferRepository.findExpirablePendingTransfersWithMember(notificationReadyCutoffTime).stream()
             .map(PendingTransferJpaEntity::toDomain)
             .toList();
     }

--- a/transfer-infra/src/main/java/org/c4marathon/assignment/infra/persistence/repository/jpa/JpaPendingTransferRepository.java
+++ b/transfer-infra/src/main/java/org/c4marathon/assignment/infra/persistence/repository/jpa/JpaPendingTransferRepository.java
@@ -20,5 +20,5 @@ public interface JpaPendingTransferRepository extends JpaRepository<PendingTrans
     List<PendingTransferJpaEntity> findRemindPendingTargetTransactionsWithMainAccount(@Param("notificationReadyCutoffTime") LocalDateTime notificationReadyCutoffTime);
 
     @Query("SELECT t FROM PendingTransferJpaEntity t LEFT JOIN t.toMainAccount m LEFT JOIN m.member WHERE t.status = org.c4marathon.assignment.enums.TransferStatus.PENDING AND t.createdAt  <= :notificationReadyCutoffTime")
-    List<PendingTransferJpaEntity> findRemindPendingTargetTransactionsWithMember(@Param("notificationReadyCutoffTime") LocalDateTime notificationReadyCutoffTime);
+    List<PendingTransferJpaEntity> findExpirablePendingTransfersWithMember(@Param("notificationReadyCutoffTime") LocalDateTime notificationReadyCutoffTime);
 }

--- a/transfer-log-domain/src/main/java/org/c4marathon/assignment/domain/model/TransferLog.java
+++ b/transfer-log-domain/src/main/java/org/c4marathon/assignment/domain/model/TransferLog.java
@@ -6,29 +6,62 @@ import org.c4marathon.assignment.domain.model.vo.AccountSnapshot;
 import org.c4marathon.assignment.enums.TransferStatus;
 import org.c4marathon.assignment.enums.TransferType;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Builder
 @Getter
 @ToString
 @EqualsAndHashCode
+@NoArgsConstructor
 @AllArgsConstructor
 public class TransferLog {
     private Long id;
     private Long parentTransferTransactionId;
-    private final AccountSnapshot from;
-    private final AccountSnapshot to;
-    private final long amount;
-    private final TransferType type;
-    private final TransferStatus status;
-    private final LocalDateTime sendTime;
-    private final LocalDateTime receiverTime;
-    private final LocalDateTime createdAt;
-    private final LocalDateTime updatedAt;
+    private AccountSnapshot from;
+    private AccountSnapshot to;
+    private long amount;
+    private TransferType type;
+    private TransferStatus status;
+    private LocalDateTime sendTime;
+    private LocalDateTime receiverTime;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @JsonCreator
+    public static TransferLog create(
+            @JsonProperty("id") Long id,
+            @JsonProperty("parentTransferTransactionId") Long parentTransferTransactionId,
+            @JsonProperty("from") AccountSnapshot from,
+            @JsonProperty("to") AccountSnapshot to,
+            @JsonProperty("amount") long amount,
+            @JsonProperty("type") TransferType type,
+            @JsonProperty("status") TransferStatus status,
+            @JsonProperty("sendTime") LocalDateTime sendTime,
+            @JsonProperty("receiverTime") LocalDateTime receiverTime,
+            @JsonProperty("createdAt") LocalDateTime createdAt,
+            @JsonProperty("updatedAt") LocalDateTime updatedAt) {
+        return TransferLog.builder()
+                .id(id)
+                .parentTransferTransactionId(parentTransferTransactionId)
+                .from(from)
+                .to(to)
+                .amount(amount)
+                .type(type)
+                .status(status)
+                .sendTime(sendTime)
+                .receiverTime(receiverTime)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .build();
+    }
 
     public static TransferLog of(Long id, Long parentTransferTransactionId, AccountSnapshot from, AccountSnapshot to, 
                                long amount, TransferType type, TransferStatus status, LocalDateTime sendTime, 

--- a/transfer-log-domain/src/main/java/org/c4marathon/assignment/domain/model/vo/AccountSnapshot.java
+++ b/transfer-log-domain/src/main/java/org/c4marathon/assignment/domain/model/vo/AccountSnapshot.java
@@ -4,6 +4,9 @@ import org.c4marathon.assignment.enums.AccountType;
 import org.c4marathon.assignment.model.Account;
 import org.c4marathon.assignment.policy.ExternalAccountPolicy;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record AccountSnapshot(Long id, AccountType type, String number) {
 	public static AccountSnapshot from(Account account) {
 		if (account == null) {
@@ -18,4 +21,12 @@ public record AccountSnapshot(Long id, AccountType type, String number) {
 		}
 		return new AccountSnapshot(policy.getId(), policy.getType(), policy.getNumber());
 	}
+
+	@JsonCreator
+    public static AccountSnapshot create(
+            @JsonProperty("id") Long id,
+            @JsonProperty("type") AccountType type,
+            @JsonProperty("number") String number) {
+        return new AccountSnapshot(id, type, number);
+    }
 }


### PR DESCRIPTION
## ⭐ 작업 분류
- [ ] 테스트
- [X] 신규 기능
- [X] 코드 수정
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 디자인 수정
- [ ] 치명적 버그 수정
- [ ] 기타 작업(주석, 스타일)

## ✅ Check List 
> 모든 항목에 대해서 확인해주세요.
- [X] 테스트가 전부 통과되었나요?  
- [X] 빌드는 성공했나요?
- [X] 모든 commit이 push 되었나요?
- [X] merge할 branch를 확인했나요?
- [X] Assignee를 지정했나요?
- [X] Label을 지정했나요?

## Test Screenshot
<!-- 아래 첨부 -->


## ⭐ 작업 개요
> 어떤 작업을 했는지 간단하게 작성해주세요.
<!-- 아래 작성 -->
* **DLQ(Dead Letter Queue) 시스템 도입을 통한 안정적인 메시지 처리:**
    * 서버 내 **PQ(Priority Queue) 자료구조**를 활용하여 DLQ를 생성하고, 실패한 메시지(특히 송금 이력 관련)를 안전하게 저장 및 관리하는 기능을 추가했습니다.
    * DLQ를 통해 **즉시 송금 시 송금 이력 남기기 과정에서 예외가 발생할 경우 재처리 로직**을 도입하여 데이터 유실 없이 안정적인 처리를 보장합니다.
- **실시간 모니터링 및 알림 기능 구현:** DLQ 현황을 실시간으로 파악하고, 임계치 초과 시 Slack 알림을 통해 운영자에게 통보합니다.
- **계좌 생성 시 잔액 초기화 및 대기 송금 만료 로직 개선:** 계좌 생성 시 잔액 초기화 값을 추가하고, 대기 송금 만료 기능의 반환값 및 트랜잭션 문제를 해결했습니다.
- 프로메테우스를 통한 자원 모니터링 추가

<br><br>
## ⭐ 작업 상세 내용
> 왜 그런 로직을 작성했는지 **자세히** 알려주세요. 👍  
기존코드에서 무엇이 수정되었는지?  
어떤 생각으로 컴포넌트를 분리하였는지?  
> >  ex) query 및 mutation 기능 연결하였습니다.  
<!-- 아래 작성 -->
**1. DLQ(Dead Letter Queue) 시스템 도입 배경 및 구현 상세:**
   기존 시스템에서는 `Transfer()` 실행 시 내부 예외로 인해 처리가 실패할 경우 해당 정보가 유실되거나, 장애/네트워크 이슈로 보상 로직이 실패해도 재시도되지 않고 실패 사유 추적이 어려웠습니다.
이러한 문제들을 해결하고자 다음과 같이 DLQ 시스템을 도입했습니다.

   * **`DeadLetterMessage` 도메인 도입:** 실패 메시지를 안전하게 저장하기 위한 DLQ 전용 엔티티인 `DeadLetterMessage`를 레코드 형태로 도입했습니다. 
   * **`DeadLetterQueueService`를 통한 책임 분리:** DLQ 저장 및 재처리 기능을 `DeadLetterQueueService`에 위임하여 단일 책임 원칙을 따르도록 했습니다. 이를 통해 메시지 타입에 따라 전략을 분기 처리할 수 있는 구조를 마련했습니다.
   * **Spring Batch/Scheduler 기반의 재처리 로직 구현:** 일정 주기마다 DLQ 메시지를 재처리하는 배치 또는 스케줄러를 구성했습니다. 
   * **`TransferUseCase.Transfer()` 내 DLQ 전송 로직 추가:** 송금 로직(`TransferUseCase.Transfer()`) 내 `try-catch` 블록에 DLQ 전송 로직을 도입하여 실패한 보상 로직이 유실 없이 저장되도록 구현했습니다. 

**2. 실시간 모니터링 및 알림 기능 구현:**
   운영 중 DLQ 대상 메시지 현황을 실시간으로 파악하고 대응하기 위해 다음과 같은 기능을 추가했습니다.
   * **DLQ 상태 및 수량 모니터링 API 추가:** "feat: DLQ 메시지 수 조회 api 추가" 커밋을 통해 DLQ의 현재 상태 및 메시지 수를 실시간으로 조회할 수 있는 API를 구현했습니다. 이는 향후 관리자용 대시보드 구현의 기반이 됩니다.
   * **Slack 알림 기능 연동:** "feat: DLQ가 임계 수치까지 올라갔을 시, slack 알림 해주는 기능 추가" 커밋을 통해 DLQ 메시지 수가 특정 임계치를 넘을 경우 Slack을 통해 운영자에게 자동 알림을 전송하는 기능을 추가했습니다. 이를 통해 문제 발생 시 신속한 인지가 가능해졌습니다.

**3. 계좌 생성 및 대기 송금 만료 로직 개선:**
   * **계좌 생성 시 잔액 초기화:** "feat: 계좌 생성시, 잔액에 대한 초기화 값 추가" 커밋을 통해 계좌 생성 시 잔액 초기화 값을 명확하게 설정하도록 개선했습니다.
   * **대기 송금 만료 기능 개선:** "fix: 대기 송금 만료 기능 반환값 추가 및 트랜잭션 문제 해결" 커밋을 통해 대기 송금 만료 기능의 반환값을 추가하고, 관련 트랜잭션 문제를 해결하여 로직의 견고함을 높였습니다.


<br><br>
## 리뷰 시간 🌼
> 리뷰 예상시간을 간략하게 작성 ex) 10m
<!-- 아래 작성 -->



<br><br>
## 기타 메시지
> 다음 스크럼에 할일 혹은 리뷰어에게 부탁할 말을 작성하시면 됩니다.
<!-- 아래 작성 -->
DLQ 수동 재처리 및 삭제 API 개발은 추후 진행 예정입니다.



<br><br>
## 이미지 업로드
> 변경 사항을 참고하기 쉽게 스크린샷 이미지를 첨부해 주세요. (시연을 위한 gif를 첨부해도 좋습니다.)
<!-- 아래 작성 -->



<br><br>
## 관련 이슈
> 관련있는 이슈를 알려주세요.
> ex) Close #1 (#이슈번호)
<!-- 아래 작성 -->
Close #22 
Close #23 

<br><br><br><br><br>
<hr>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **신규 기능**
  * Dead Letter Queue(DLQ) 도메인 및 인프라 모듈이 추가되어, 전송 실패 로그를 DLQ에 저장 및 재처리할 수 있습니다.
  * DLQ 메시지 개수 조회 REST API가 추가되었습니다.
  * DLQ 임계치 초과 시 슬랙 알림 기능이 도입되었습니다.
  * 메인 계좌 낙관적 락 기반 입금 기능이 추가되었습니다.
  * 메인 계좌에서 적금 계좌로 계좌번호 기반 이체 기능이 추가되었습니다.

* **기능 개선**
  * 이체 로그, 계좌 스냅샷, 이체 타입 등 주요 도메인 객체에 대해 JSON 직렬화/역직렬화 지원이 강화되었습니다.
  * 메인 계좌 생성 시 잔액 및 일일 충전액이 0으로 초기화됩니다.
  * 대기 중인 이체 만료 처리 및 리마인드 로직이 개선되었습니다.
  * 대기 중인 이체 만료 처리 로직이 메서드 분리 및 명칭 변경으로 정비되었습니다.
  * 로그 및 메시지 포맷 일부가 개선되었습니다.
  * 애플리케이션 설정 파일의 로깅 구성 방식이 YAML 형식으로 변경되었습니다.

* **버그 수정**
  * 멤버 객체의 동등성 비교(`equals`, `hashCode`)가 ID 기준으로 동작하도록 개선되었습니다.

* **환경 및 의존성**
  * Jackson 라이브러리 및 Slack 라이브러리 버전이 업데이트되었습니다.
  * Gradle 프로젝트에 DLQ 관련 신규 모듈과 의존성이 추가되었습니다.
  * `.gitignore` 파일에 최상위 `build/` 및 `bin/` 디렉토리가 명시적으로 추가되었습니다.

* **기타**
  * 불필요한 import가 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->